### PR TITLE
Adjust example code for imageForSize helper

### DIFF
--- a/src/image-helpers.js
+++ b/src/image-helpers.js
@@ -8,7 +8,7 @@ export default {
    * Images do not scale up.
    *
    * @example
-   * const url = client.image.imageForSize(product.variants[0].image, {maxWidth: 50, maxHeight: 50});
+   * const url = client.image.helpers.imageForSize(product.variants[0].image, {maxWidth: 50, maxHeight: 50});
    *
    * @memberof ImageHelpers
    * @method imageForSize


### PR DESCRIPTION
The imageForSize method seems be accessible through the `helpers` namespace which doesn't reflect in the docs.